### PR TITLE
Set LDAP/SSO integration as "not available/relevant" in check_process

### DIFF
--- a/check_process
+++ b/check_process
@@ -24,7 +24,7 @@
 	Level 1=auto
 	Level 2=auto
 	Level 3=auto
-	Level 4=0
+	Level 4=na
 	Level 5=auto
 	Level 6=auto
 	Level 7=auto


### PR DESCRIPTION
I'm not sure because I don't know this app, but as far as I understand, LDAP/SSO integration might be irrelevant for this app, so we can set level 4 as "na" which might in turn increase this app's level